### PR TITLE
Added proper imports for Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.2"
 script: nosetests -v

--- a/murl.py
+++ b/murl.py
@@ -1,7 +1,11 @@
 # coding: utf-8
 
-from urllib import urlencode
-from urlparse import urlparse, urlunparse, parse_qs, ParseResult
+try:
+    from urllib.parse import (urlencode, urlparse, urlunparse,
+                              parse_qs, ParseResult)
+except ImportError:
+    from urllib import urlencode
+    from urlparse import urlparse, urlunparse, parse_qs, ParseResult
 
 #: Parts for RFC 3986 URI syntax
 #: <scheme>://<netloc>/<path>;<params>?<query>#<fragment>


### PR DESCRIPTION
Hey,

I've added the right imports for Python 3. The unit-tests now pass on py3.2 so I guess that this is all it takes to make it work on Python 3. I also went ahead and added Python 3.2 to travis.yml
